### PR TITLE
Fix extensionless serve routes

### DIFF
--- a/docs/pages/index.js
+++ b/docs/pages/index.js
@@ -14,8 +14,7 @@ export default context => html`
   <section>
     <p>${context.data.libraryMessage}</p>
     <ol>
-      <li><a href="https://github.com/popeindustries/lit-html-server" rel="noopener">lit-html-server</a></li>
-      <li><a href="https://github.com/Polymer/lit-html" rel="noopener">lit-html</a></li>
+      <li><a href="https://github.com/lit/lit" rel="noopener">lit</a></li>
       <li><a href="https://github.com/expressjs/express" rel="noopener">express</a></li>
       <li><a href="https://github.com/markdown-it/markdown-it" rel="noopener">markdown-it</a></li>
     </ol>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "orison",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "orison",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "license": "ISC",
       "dependencies": {
         "@lit-labs/ssr": "4.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "orison",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "A static site generator built on top of lit-html.",
   "keywords": [
     "Static site generation",

--- a/src/project.ts
+++ b/src/project.ts
@@ -1094,8 +1094,22 @@ function normalizeRequestedRoute(routePath: string, fragmentName: string) {
 
   return {
     fragmentOnly: false,
-    routePath: routePath === "" ? "/" : routePath,
+    routePath: normalizeServeRoutePath(routePath === "" ? "/" : routePath),
   };
+}
+
+function normalizeServeRoutePath(routePath: string) {
+  if (
+    routePath === "/" ||
+    routePath.endsWith("/") ||
+    path.extname(routePath) ||
+    routePath.endsWith("/data.json") ||
+    routePath === "/data.json"
+  ) {
+    return routePath;
+  }
+
+  return `${routePath}.html`;
 }
 
 async function renderUnknown(value: unknown): Promise<string> {


### PR DESCRIPTION
## Summary
- normalize extensionless HTML requests during dev serving
- bump Orison to 2.0.1 for the serve route fix
- update the docs dependency link for Lit

## Validation
- npm test
- validated /timeline/page-2 and /timeline/page-2.html against the packaged and published 2.0.1 release in phanoria-adventure