### PR TITLE
Add detailed build logging and publish workflow

### DIFF
--- a/.github/prompts/publish-current-changes.prompt.md
+++ b/.github/prompts/publish-current-changes.prompt.md
@@ -1,0 +1,8 @@
+---
+name: publish-current-changes
+description: "Follow the publish-current-changes skill when asked to publish the current work"
+argument-hint: "Optional commit message or publishing target"
+agent: "agent"
+---
+
+Follow the instructions in [publish-current-changes](../skills/publish-current-changes/SKILL.md).

--- a/.github/skills/publish-current-changes/SKILL.md
+++ b/.github/skills/publish-current-changes/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: publish-current-changes
+description: When you are asked to publish the current work
+argument-hint: Optional commit message or publishing target
+user-invocable: true
+---
+
+# Publish Current Changes
+
+## When to Use
+
+- When you are asked to publish the current work.
+
+## Procedure
+
+1. Inspect the current git state and review the current changes.
+2. Bump the minor version in `package.json`.
+3. Create a new branch for the changes with a descriptive name based on the commit message or change summary.
+4. Validate before publishing by running `npm run test`.
+5. Stage everything.
+6. Commit the changes and provide a detailed commit message.
+7. Push the current branch.
+8. Open a pull request on Github using `gh` cli.
+9. Update the pull request description with lots of details.
+10. Merge the pull request.
+11. Check out main and pull the latest changes to ensure the local repository is up to date.
+12. Use `npm publish` and ask me to authenticate with npm.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "orison",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "description": "A static site generator built on top of lit-html.",
   "keywords": [
     "Static site generation",

--- a/src/project.ts
+++ b/src/project.ts
@@ -142,12 +142,41 @@ export class OrisonProject {
   }
 
   async build(): Promise<BuildResult> {
-    const site = await this.inspectSite();
-    process.env.ORISON_PROJECT_ROOT = this.options.rootPath;
-    const outputs = await this.renderBuildOutputs(site.tree);
+    const startedAt = Date.now();
+    this.logBuild(`starting build in ${this.relativeToRoot(this.options.rootPath)}`);
+    this.logBuild(`pages root: ${this.relativeToRoot(this.options.pagesRoot)}`);
+    this.logBuild(`output root: ${this.relativeToRoot(this.options.outputRoot)}`);
 
+    this.logBuild("inspecting site structure");
+    const site = await this.inspectSite();
+    const staticFiles = await this.getStaticFiles();
+
+    this.logBuild(
+      `discovered ${countDirectories(site.tree)} directories and ${site.pages.length} page definitions`,
+    );
+    this.logPageDefinitions(site.pages);
+    if (staticFiles.length === 0) {
+      this.logBuild("no static assets found");
+    } else {
+      this.logBuild(`found ${staticFiles.length} static asset files`);
+      this.logStaticFiles(staticFiles);
+    }
+
+    process.env.ORISON_PROJECT_ROOT = this.options.rootPath;
+
+    this.logBuild("rendering build outputs");
+    const outputs = await this.renderBuildOutputs(site.tree);
+    this.logBuild(`prepared ${outputs.length} output files`);
+    this.logRenderedOutputs(outputs);
+
+    this.logBuild("copying static assets");
     await this.copyStaticDirectory();
+
+    this.logBuild("writing rendered outputs");
     await Promise.all(outputs.map((output) => this.writeOutput(output)));
+
+    const elapsedMs = Date.now() - startedAt;
+    this.logBuild(`build completed in ${elapsedMs}ms`);
 
     return {
       files: outputs.map((output) => output.outputPath),
@@ -251,6 +280,57 @@ export class OrisonProject {
 
   get outputRoot() {
     return this.options.outputRoot;
+  }
+
+  private logBuild(message: string) {
+    console.info(`[orison:build] ${message}`);
+  }
+
+  private logPageDefinitions(pages: PageDefinition[]) {
+    for (const page of pages) {
+      if (page.kind === "list") {
+        this.logBuild(
+          `page list ${this.relativeToRoot(page.sourcePath)} -> dynamic routes under ${page.routeBase}`,
+        );
+        continue;
+      }
+
+      const routes = this.getDirectRoutes(page);
+      this.logBuild(
+        `page file ${this.relativeToRoot(page.sourcePath)} -> ${routes.join(", ")}`,
+      );
+    }
+  }
+
+  private logRenderedOutputs(outputs: RenderedOutput[]) {
+    for (const output of outputs) {
+      this.logBuild(
+        `output ${output.contentType} ${output.routePath} -> ${this.relativeToRoot(output.outputPath)} (${formatByteSize(output.body.length)})`,
+      );
+    }
+  }
+
+  private logStaticFiles(filePaths: string[]) {
+    for (const filePath of filePaths) {
+      this.logBuild(`static asset ${this.relativeToRoot(filePath)}`);
+    }
+  }
+
+  private async getStaticFiles() {
+    if (!(await exists(this.staticRoot))) {
+      return [];
+    }
+
+    return walkFiles(this.staticRoot);
+  }
+
+  private relativeToRoot(targetPath: string) {
+    const relativePath = path.relative(this.options.rootPath, targetPath);
+    if (relativePath === "") {
+      return ".";
+    }
+
+    return toPosix(relativePath);
   }
 
   private async copyStaticDirectory() {
@@ -956,6 +1036,16 @@ function compareDirectories(left: DirectoryNode, right: DirectoryNode) {
   return left.name.localeCompare(right.name);
 }
 
+function countDirectories(directory: DirectoryNode): number {
+  return (
+    1 +
+    directory.children.reduce(
+      (total, child) => total + countDirectories(child),
+      0,
+    )
+  );
+}
+
 function dedupeOutputs(outputs: RenderedOutput[]) {
   const seen = new Map<string, RenderedOutput>();
   for (const output of outputs) {
@@ -983,6 +1073,10 @@ async function exists(targetPath: string) {
   } catch {
     return false;
   }
+}
+
+function formatByteSize(value: number) {
+  return new Intl.NumberFormat("en-US").format(value) + " bytes";
 }
 
 function getParents(directory: DirectoryNode) {


### PR DESCRIPTION
## Summary
This change improves the build experience and adds a lightweight publishing workflow for Copilot-driven repository maintenance.

### Build logging
- add detailed [orison:build] logging at the OrisonProject.build() level
- report build roots, site inspection, page definition discovery, static asset discovery, output generation, write phases, and total elapsed time
- include per-page route information and per-output file destinations with byte sizes so build activity is easy to trace during build and docs:build

### Copilot customization
- add a workspace skill named publish-current-changes
- add a matching workspace prompt that delegates to the skill instructions
- keep the prompt minimal so the skill remains the single place for the publish workflow

### Release metadata
- bump the package version from 2.0.1 to 2.1.0

## Validation
- npm test

## Additional context
- the docs build still prints the existing Node experimental warning related to the SSR dependency load path
- the warning did not block the build and was not introduced by this change
