### PR TITLE
Release 2.5.0 with build output directory summary

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,4 @@
+[build]
+  command = "npm run build"
+  publish = "docs/dist"
+  environment = { NODE_VERSION = "24.16.0" }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "orison",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "description": "A static site generator built on top of lit-html.",
   "keywords": [
     "Static site generation",
@@ -51,6 +51,7 @@
   },
   "scripts": {
     "start": "npm run orison:build && run-p orison:watch docs:serve",
+    "build": "run-s orison:build docs:build",
     "orison:watch": "rollup -c -w",
     "orison:build": "rm -rf bin && rollup -c",
     "docs:serve": "node ./bin/cli.js serve ./docs",

--- a/src/project/orison-project.ts
+++ b/src/project/orison-project.ts
@@ -88,7 +88,9 @@ export class OrisonProject {
     await Promise.all(outputs.map((output) => this.writeOutput(output)));
 
     const elapsedMs = Date.now() - startedAt;
-    this.logBuild(`build completed in ${elapsedMs}ms`);
+    this.logBuild(
+      `build completed in ${elapsedMs}ms -> ${this.relativeToRoot(this.options.outputRoot)}`,
+    );
 
     return {
       files: outputs.map((output) => output.outputPath),


### PR DESCRIPTION
## Summary
- bump the package version from 2.4.0 to 2.5.0 for this release
- add a top-level `npm run build` command that runs the library build and docs build together
- add a Netlify configuration file that builds with Node 24.16.0 and publishes from `docs/dist`
- include the output directory in the final `[orison:build]` completion message

## Why
The CLI already reports the configured output root at the start of a build, but the final completion message previously stopped at elapsed time. Including the output directory in the closing line makes the last line actionable when users are scanning logs locally or in CI.

The new repository build command and Netlify configuration align deployment with the generated documentation output so the project can be built and published consistently.

## Validation
- `npm run test`
- `npm run fix`

## Notes
The full test suite passed. The test harness emitted Node engine warnings because the test case installs ran under Node 22.12.0 in that subprocess environment, but the Orison builds and file comparison checks still completed successfully.