### PR TITLE
Release 2.6.0 with Netlify build fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "orison",
-  "version": "2.4.0",
+  "version": "2.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "orison",
-      "version": "2.4.0",
+      "version": "2.6.0",
       "license": "ISC",
       "dependencies": {
         "@lit-labs/ssr": "4.1.0",
@@ -34,6 +34,7 @@
         "npm-run-all": "^4.1.5",
         "prettier": "^3.5.3",
         "rollup": "^4.41.1",
+        "tslib": "^2.8.1",
         "typescript": "^5.8.3"
       },
       "engines": {
@@ -5035,9 +5036,7 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true,
-      "license": "0BSD",
-      "optional": true,
-      "peer": true
+      "license": "0BSD"
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "orison",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "description": "A static site generator built on top of lit-html.",
   "keywords": [
     "Static site generation",
@@ -47,6 +47,7 @@
     "npm-run-all": "^4.1.5",
     "prettier": "^3.5.3",
     "rollup": "^4.41.1",
+    "tslib": "^2.8.1",
     "typescript": "^5.8.3"
   },
   "scripts": {


### PR DESCRIPTION
## Summary
- bump Orison from 2.5.0 to 2.6.0
- add `tslib` to the devDependencies used by the Rollup TypeScript build
- update the lockfile so install-time builds resolve the new dependency consistently

## Why
The Netlify docs deploy failed during `npm install` because the package `prepare` script runs `rollup -c`, and `@rollup/plugin-typescript` requires `tslib` to be installed. The repository did not declare `tslib`, so the deployment failed before the actual site build could run.

Adding `tslib` fixes the install-time build path used by Netlify and keeps the local release flow consistent.

## Validation
- `npm install`
- `nvm use 24.16.0 && npm run test`
- `nvm use 24.16.0 && npm run fix`